### PR TITLE
Exports InputType  interface 

### DIFF
--- a/types/reactstrap/lib/Input.d.ts
+++ b/types/reactstrap/lib/Input.d.ts
@@ -1,6 +1,6 @@
 import { CSSModule } from '../index';
 
-type InputType =
+export type InputType =
   | 'text'
   | 'email'
   | 'select'


### PR DESCRIPTION
Please fill in this template.

- [ x] Use a meaningful title for the pull request. Include the name of the package modified.
- [ x] Test the change in your own code. (Compile and run.)
- [ ] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x ] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

This is a small change that exports `InputType` reason for this so that it can be used as a type variable for example when you wrap `<input/>` into a higher container the types can be different depending on the use case so importing the interface and using it as a reference is good idea

